### PR TITLE
Fix Windows blockers

### DIFF
--- a/ca.go
+++ b/ca.go
@@ -1,59 +1,10 @@
 package main
 
-import (
-	"crypto/x509"
-	"fmt"
-	"io/ioutil"
-	"os"
-	"os/exec"
-	"runtime"
-)
+import "crypto/x509"
 
-// SetSystemCAPool tries a bunch of heuristics to load the system CA
-//  certificates.  This is mostly stolen from crypto/x509 and I have no
-//  idea why it is not exported.
-func SetSystemCAPool(capool *x509.CertPool) error {
-	// Fail immediately if Windows, if Darwin try the magic keychain extractor,
-	//  otherwise loop through certfiles until we can open one of them, and
-	//  try that one (only).
-	var certfiles = []string{
-		"/etc/ssl/certs/ca-certificates.crt",     // Debian/Ubuntu/Gentoo etc.
-		"/etc/pki/tls/certs/ca-bundle.crt",       // Fedora/RHEL
-		"/etc/ssl/ca-bundle.pem",                 // OpenSUSE
-		"/etc/pki/tls/cacert.pem",                // OpenELEC
-		"/usr/local/share/certs/ca-root-nss.crt", // FreeBSD/DragonFly
-		"/etc/ssl/cert.pem",                      // OpenBSD
-		"/etc/openssl/certs/ca-certificates.crt", // NetBSD
-		"/sys/lib/tls/ca.pem",                    // Plan9
-		"/etc/certs/ca-certificates.crt",         // Solaris 11.2+
-		"/etc/ssl/cacert.pem",                    // OmniOS
-		"/system/etc/security/cacerts",           // Android
-	}
-
-	switch runtime.GOOS {
-	case "windows":
-		return fmt.Errorf("SetSystemCAPool not implemented on Windows.")
-	case "darwin":
-		cmd := exec.Command("/usr/bin/security", "find-certificate", "-a", "-p", "/System/Library/Keychains/SystemRootCertificates.keychain")
-		data, err := cmd.Output()
-		if err != nil {
-			return err
-		}
-		if !capool.AppendCertsFromPEM(data) {
-			return fmt.Errorf("No certificates could be loaded from SystemRootCertificates.keychain.")
-		}
-		return nil
-	default:
-		for _, cf := range certfiles {
-			if _, err := os.Stat(cf); err == nil {
-				if cfc, err := ioutil.ReadFile(cf); err == nil {
-					if !capool.AppendCertsFromPEM(cfc) {
-						return fmt.Errorf("Could not load certificates from %s: %v", cf, err)
-					}
-					return nil
-				}
-			}
-		}
-	}
-	return fmt.Errorf("Could not find certificates in any of: %v", certfiles)
+// SetSystemCAPool loads the system's root CA list into the provided CertPool using
+// the OS-preferred method. Leans heavily on unexported funcs from crypto/x509.
+func SetSystemCAPool(capool *x509.CertPool) (pool *x509.CertPool, err error) {
+	pool, err = loadSysroots(capool)
+	return
 }

--- a/logging.go
+++ b/logging.go
@@ -1,13 +1,11 @@
 package main
 
 import (
-	log "github.com/Sirupsen/logrus"
-	syslogrus "github.com/Sirupsen/logrus/hooks/syslog"
-	"github.com/olebedev/config"
-	"io/ioutil"
-	"log/syslog"
 	"os"
 	"strings"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/olebedev/config"
 )
 
 func configLogging(cfg *config.Config) {
@@ -33,14 +31,10 @@ func configLogging(cfg *config.Config) {
 	}
 
 	if strings.HasPrefix(logDest, "syslog://") {
-		addr := strings.TrimPrefix(logDest, "syslog://")
-		hook, err := syslogrus.NewSyslogHook("udp", addr, syslog.LOG_INFO, "tlspxy")
-		if err != nil {
-			log.Error("Unable to connect to local syslog daemon")
-		} else {
-			log.AddHook(hook)
+		if err := syslogging(strings.TrimPrefix(logDest, "syslog://")); err != nil {
+			log.Error(err)
+			os.Exit(1)
 		}
-		log.SetOutput(ioutil.Discard)
 		return
 	}
 

--- a/roots_darwin.go
+++ b/roots_darwin.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"crypto/x509"
+	"fmt"
+	"os/exec"
+)
+
+// loadSysroots for Linux uses OSX's security tool to pull the system roots. This takes a while...
+func loadSysroots(roots *x509.CertPool) (*x509.CertPool, error) {
+	cmd := exec.Command("/usr/bin/security", "find-certificate", "-a", "-p", "/System/Library/Keychains/SystemRootCertificates.keychain")
+	data, err := cmd.Output()
+	if err != nil {
+		return roots, err
+	}
+	if !roots.AppendCertsFromPEM(data) {
+		return roots, fmt.Errorf("No certificates could be loaded from SystemRootCertificates.keychain.")
+	}
+	return roots, nil
+}

--- a/roots_linux.go
+++ b/roots_linux.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+)
+
+// StandardCertfiles is a list of common root CA locations on various distros
+var StandardCertfiles = []string{
+	"/etc/ssl/certs/ca-certificates.crt",     // Debian/Ubuntu/Gentoo etc.
+	"/etc/pki/tls/certs/ca-bundle.crt",       // Fedora/RHEL
+	"/etc/ssl/ca-bundle.pem",                 // OpenSUSE
+	"/etc/pki/tls/cacert.pem",                // OpenELEC
+	"/usr/local/share/certs/ca-root-nss.crt", // FreeBSD/DragonFly
+	"/etc/ssl/cert.pem",                      // OpenBSD
+	"/etc/openssl/certs/ca-certificates.crt", // NetBSD
+	"/sys/lib/tls/ca.pem",                    // Plan9
+	"/etc/certs/ca-certificates.crt",         // Solaris 11.2+
+	"/etc/ssl/cacert.pem",                    // OmniOS
+	"/system/etc/security/cacerts",           // Android
+}
+
+// loadSysroots for Linux attempts to load all of the StandardCertfiles
+func loadSysroots(roots *x509.CertPool) (*x509.CertPool, error) {
+	results := roots
+	for _, cf := range StandardCertfiles {
+		if fileExists(cf) {
+			if cfc, err := ioutil.ReadFile(cf); err == nil {
+				if !results.AppendCertsFromPEM(cfc) {
+					return roots, fmt.Errorf("Could not load certificates from %s: %v", cf, err)
+				}
+				return results, nil
+			}
+		}
+	}
+	return results, nil
+}

--- a/roots_windows.go
+++ b/roots_windows.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"crypto/x509"
+	"syscall"
+	"unsafe"
+)
+
+// loadSysroots for Windows is copied 1:1 from the unexported func in crypto/x509
+func loadSysroots(roots *x509.CertPool) (*x509.CertPool, error) {
+	const CRYPT_E_NOT_FOUND = 0x80092004
+
+	store, err := syscall.CertOpenSystemStore(0, syscall.StringToUTF16Ptr("ROOT"))
+	if err != nil {
+		return nil, err
+	}
+	defer syscall.CertCloseStore(store, 0)
+
+	var cert *syscall.CertContext
+	for {
+		cert, err = syscall.CertEnumCertificatesInStore(store, cert)
+		if err != nil {
+			if errno, ok := err.(syscall.Errno); ok {
+				if errno == CRYPT_E_NOT_FOUND {
+					break
+				}
+			}
+			return nil, err
+		}
+		if cert == nil {
+			break
+		}
+		// Copy the buf, since ParseCertificate does not create its own copy.
+		buf := (*[1 << 20]byte)(unsafe.Pointer(cert.EncodedCert))[:]
+		buf2 := make([]byte, cert.Length)
+		copy(buf2, buf)
+		if c, err := x509.ParseCertificate(buf2); err == nil {
+			roots.AddCert(c)
+		}
+	}
+	return roots, nil
+}

--- a/syslog_darwin.go
+++ b/syslog_darwin.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log/syslog"
+
+	log "github.com/Sirupsen/logrus"
+	syslogrus "github.com/Sirupsen/logrus/hooks/syslog"
+)
+
+func syslogging(addr string) error {
+	hook, err := syslogrus.NewSyslogHook("udp", addr, syslog.LOG_INFO, "tlspxy")
+	if err != nil {
+		return fmt.Errorf("Unable to connect to syslog daemon: %v", err)
+	}
+	log.AddHook(hook)
+	log.SetOutput(ioutil.Discard)
+	return nil
+}

--- a/syslog_linux.go
+++ b/syslog_linux.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log/syslog"
+
+	log "github.com/Sirupsen/logrus"
+	syslogrus "github.com/Sirupsen/logrus/hooks/syslog"
+)
+
+func syslogging(addr string) error {
+	hook, err := syslogrus.NewSyslogHook("udp", addr, syslog.LOG_INFO, "tlspxy")
+	if err != nil {
+		return fmt.Errorf("Unable to connect to syslog daemon: %v", err)
+	} else {
+		log.AddHook(hook)
+	}
+	log.SetOutput(ioutil.Discard)
+	return nil
+}

--- a/syslog_windows.go
+++ b/syslog_windows.go
@@ -4,6 +4,6 @@ import (
 	"fmt"
 )
 
-func syslogging() error {
+func syslogging(addr string) error {
 	return fmt.Errorf("Using syslog from Windows is not supported.")
 }

--- a/syslog_windows.go
+++ b/syslog_windows.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"fmt"
+)
+
+func syslogging() error {
+	return fmt.Errorf("Using syslog from Windows is not supported.")
+}

--- a/tls.go
+++ b/tls.go
@@ -47,9 +47,11 @@ func LoadTLSConfigFromFiles(cert, key, ca string, loadSystemRoots bool) (tlsConf
 	caPool = x509.NewCertPool()
 
 	if loadSystemRoots {
-		if err = SetSystemCAPool(caPool); err != nil {
+		var pool *x509.CertPool
+		if pool, err = SetSystemCAPool(caPool); err != nil {
 			return
 		}
+		caPool = pool
 	}
 
 	if len(ca) > 0 {


### PR DESCRIPTION
Fixed 2 major issues that prevented compiling on Windows:

1. Correctly load the system root CAs from the preferred platform store on Linux/Darwin/Windows
    1. On Darwin, this means using `/usr/bin/security` (the performance is bad and it should feel bad)
    2. On Windows we are using native syscalls to open and load the Windows cert store
1. Only support the syslog hook from Linux/Darwin (generates a compile error on Windows)

Now this package is `go get`-able from Windows (with the same [caveats](https://github.com/colebrumley/tlspxy/wiki/Installation) as always)