### PR TITLE
Allow TLS connection to remote when no key or cert provided

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -27,6 +27,7 @@ var (
 		"remote": map[string]interface{}{
 			"addr": "",
 			"tls": map[string]interface{}{
+				"enable":   true,
 				"verify":   true,
 				"cert":     "",
 				"key":      "",

--- a/remotetls.go
+++ b/remotetls.go
@@ -9,6 +9,7 @@ import (
 )
 
 func configRemoteTLS(cfg *config.Config) (tlsConf *tls.Config, err error) {
+	isTLS := cfg.UBool("remote.tls.enable", true)
 	cert := cfg.UString("remote.tls.cert")
 	key := cfg.UString("remote.tls.key")
 	ca := cfg.UString("remote.tls.ca")
@@ -21,9 +22,8 @@ func configRemoteTLS(cfg *config.Config) (tlsConf *tls.Config, err error) {
 			return
 		}
 		log.Debugln("Loading remote TLS config succeeded")
-	} else {
-		tlsConf = nil
-		err = nil
+	} else if isTLS {
+		tlsConf = &tls.Config{}
 	}
 
 	if doVerify && useSysRoots {


### PR DESCRIPTION
This allows TLS connections to remotes without a client cert. The old behavior simply downgraded to non-TLS. I've added a config parameter that allows remote TLS to be disabled, to restore the previous behavior.